### PR TITLE
compatible different command line style for find jar path

### DIFF
--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/MainJarPathFinder.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/MainJarPathFinder.java
@@ -44,9 +44,13 @@ class MainJarPathFinder {
   @Nullable
   private Path getJarPathFromProcessHandle() {
     String[] javaArgs = getProcessHandleArguments.get();
-    for (int i = 0; i < javaArgs.length; ++i) {
-      if ("-jar".equals(javaArgs[i]) && (i < javaArgs.length - 1)) {
-        return Paths.get(javaArgs[i + 1]);
+    boolean jarOptionFound = false;
+    for (String javaArg : javaArgs) {
+      if ("-jar".equals(javaArg)) {
+        jarOptionFound = true;
+      }
+      if (jarOptionFound && !javaArg.startsWith("-")) {
+        return Paths.get(javaArg);
       }
     }
     return null;


### PR DESCRIPTION
compatible command like : **java -jar -XX:MaxRAM=128m app.jar**
The JAR file name does not always come immediately after the **-jar** command; there may be other JVM parameters in between the two.

by now, if we use the    java -jar -XX:MaxRAM=128m app.jar command to start  the applicaion. we  can not get the real jar name.
we will get the warn log like below:
`
otel.javaagent 2024-10-29 09:24:19:600 +0000] [main] WARN io.opentelemetry.instrumentation.resources.ManifestResourceProvider - Error reading manifest
java.nio.file.NoSuchFileException: -XX:MaxRAM=128m
`
